### PR TITLE
fix: Remove sensitive attribute from encryption config variable

### DIFF
--- a/variables-atlas.tf
+++ b/variables-atlas.tf
@@ -186,5 +186,4 @@ variable "encryption_provider_config" {
   description = "(Optional) Cloud-provider-specific encryption configuration passed from the cloud module. AWS: IAM role ARN + KMS key ARN + region. GCP: KMS key version resource ID. AZURE: subscription ID + resource group + key vault name + key identifier. Auth identifiers (GCP SA email, Azure app/SP/tenant) are sourced from mongodbatlas_cloud_provider_access_setup outputs."
   type        = any
   default     = {}
-  sensitive   = true
 }


### PR DESCRIPTION
## Summary
- Removes the `sensitive = true` attribute from the `encryption_provider_config` variable in `variables-atlas.tf`
- This attribute caused issues as it is not valid for `type = any` variables in certain Terraform contexts

## Test plan
- [ ] Verify `terraform validate` passes
- [ ] Verify no plan output is masked unexpectedly after this change

+semver: fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)