### PR TITLE
docs: add missing output descriptions and regenerate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,12 +476,12 @@ Available targets:
 | <a name="output_cloud_provider_setup_gcp_service_account"></a> [cloud\_provider\_setup\_gcp\_service\_account](#output\_cloud\_provider\_setup\_gcp\_service\_account) | Atlas GCP service account email — grant this SA roles/cloudkms.cryptoKeyEncrypterDecrypter on the KMS key (GCP) |
 | <a name="output_cloud_provider_setup_role_id"></a> [cloud\_provider\_setup\_role\_id](#output\_cloud\_provider\_setup\_role\_id) | MongoDB Atlas role ID from the cloud provider access setup |
 | <a name="output_encryption_at_rest_id"></a> [encryption\_at\_rest\_id](#output\_encryption\_at\_rest\_id) | MongoDB Atlas encryption-at-rest configuration ID |
-| <a name="output_imported_alert_json"></a> [imported\_alert\_json](#output\_imported\_alert\_json) | n/a |
-| <a name="output_imported_alert_statement"></a> [imported\_alert\_statement](#output\_imported\_alert\_statement) | n/a |
-| <a name="output_project_backup_policy_id"></a> [project\_backup\_policy\_id](#output\_project\_backup\_policy\_id) | n/a |
-| <a name="output_project_creation_timestamp"></a> [project\_creation\_timestamp](#output\_project\_creation\_timestamp) | n/a |
-| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | n/a |
-| <a name="output_project_name"></a> [project\_name](#output\_project\_name) | n/a |
+| <a name="output_imported_alert_json"></a> [imported\_alert\_json](#output\_imported\_alert\_json) | JSON representation of current Atlas alert configurations suitable for copying into settings.alerts (only populated when generate\_import = true) |
+| <a name="output_imported_alert_statement"></a> [imported\_alert\_statement](#output\_imported\_alert\_statement) | Ready-to-run `tofu import` commands for every existing alert in the project (only populated when generate\_import = true) |
+| <a name="output_project_backup_policy_id"></a> [project\_backup\_policy\_id](#output\_project\_backup\_policy\_id) | Backup compliance policy ID; null when backup compliance is disabled |
+| <a name="output_project_creation_timestamp"></a> [project\_creation\_timestamp](#output\_project\_creation\_timestamp) | ISO-8601 timestamp of when the Atlas project was created |
+| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | MongoDB Atlas project ID |
+| <a name="output_project_name"></a> [project\_name](#output\_project\_name) | Resolved MongoDB Atlas project name |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -63,9 +63,9 @@
 | <a name="output_cloud_provider_setup_gcp_service_account"></a> [cloud\_provider\_setup\_gcp\_service\_account](#output\_cloud\_provider\_setup\_gcp\_service\_account) | Atlas GCP service account email — grant this SA roles/cloudkms.cryptoKeyEncrypterDecrypter on the KMS key (GCP) |
 | <a name="output_cloud_provider_setup_role_id"></a> [cloud\_provider\_setup\_role\_id](#output\_cloud\_provider\_setup\_role\_id) | MongoDB Atlas role ID from the cloud provider access setup |
 | <a name="output_encryption_at_rest_id"></a> [encryption\_at\_rest\_id](#output\_encryption\_at\_rest\_id) | MongoDB Atlas encryption-at-rest configuration ID |
-| <a name="output_imported_alert_json"></a> [imported\_alert\_json](#output\_imported\_alert\_json) | n/a |
-| <a name="output_imported_alert_statement"></a> [imported\_alert\_statement](#output\_imported\_alert\_statement) | n/a |
-| <a name="output_project_backup_policy_id"></a> [project\_backup\_policy\_id](#output\_project\_backup\_policy\_id) | n/a |
-| <a name="output_project_creation_timestamp"></a> [project\_creation\_timestamp](#output\_project\_creation\_timestamp) | n/a |
-| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | n/a |
-| <a name="output_project_name"></a> [project\_name](#output\_project\_name) | n/a |
+| <a name="output_imported_alert_json"></a> [imported\_alert\_json](#output\_imported\_alert\_json) | JSON representation of current Atlas alert configurations suitable for copying into settings.alerts (only populated when generate\_import = true) |
+| <a name="output_imported_alert_statement"></a> [imported\_alert\_statement](#output\_imported\_alert\_statement) | Ready-to-run `tofu import` commands for every existing alert in the project (only populated when generate\_import = true) |
+| <a name="output_project_backup_policy_id"></a> [project\_backup\_policy\_id](#output\_project\_backup\_policy\_id) | Backup compliance policy ID; null when backup compliance is disabled |
+| <a name="output_project_creation_timestamp"></a> [project\_creation\_timestamp](#output\_project\_creation\_timestamp) | ISO-8601 timestamp of when the Atlas project was created |
+| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | MongoDB Atlas project ID |
+| <a name="output_project_name"></a> [project\_name](#output\_project\_name) | Resolved MongoDB Atlas project name |

--- a/import.tf
+++ b/import.tf
@@ -78,9 +78,11 @@ data "mongodbatlas_alert_configurations" "import" {
 }
 
 output "imported_alert_statement" {
-  value = var.generate_import ? join("\n", local.import_statements) : null
+  description = "Ready-to-run `tofu import` commands for every existing alert in the project (only populated when generate_import = true)"
+  value       = var.generate_import ? join("\n", local.import_statements) : null
 }
 
 output "imported_alert_json" {
-  value = var.generate_import ? nonsensitive(jsonencode(local.alert_yaml)) : null
+  description = "JSON representation of current Atlas alert configurations suitable for copying into settings.alerts (only populated when generate_import = true)"
+  value       = var.generate_import ? nonsensitive(jsonencode(local.alert_yaml)) : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,19 +8,23 @@
 #
 
 output "project_name" {
-  value = mongodbatlas_project.this.name
+  description = "Resolved MongoDB Atlas project name"
+  value       = mongodbatlas_project.this.name
 }
 
 output "project_id" {
-  value = mongodbatlas_project.this.id
+  description = "MongoDB Atlas project ID"
+  value       = mongodbatlas_project.this.id
 }
 
 output "project_creation_timestamp" {
-  value = mongodbatlas_project.this.created
+  description = "ISO-8601 timestamp of when the Atlas project was created"
+  value       = mongodbatlas_project.this.created
 }
 
 output "project_backup_policy_id" {
-  value = try(var.settings.backup_compliance.enabled, false) ? mongodbatlas_backup_compliance_policy.this[0].id : null
+  description = "Backup compliance policy ID; null when backup compliance is disabled"
+  value       = try(var.settings.backup_compliance.enabled, false) ? mongodbatlas_backup_compliance_policy.this[0].id : null
 }
 
 output "cloud_provider_setup_role_id" {


### PR DESCRIPTION
## Summary

- Add `description` fields to six outputs that were previously undocumented (`project_name`, `project_id`, `project_creation_timestamp`, `project_backup_policy_id`, `imported_alert_statement`, `imported_alert_json`)
- Regenerate `README.md` and `docs/terraform.md` via `make readme` so the Outputs reference table no longer shows `n/a` entries
- Documentation now fully complies with the project's documentation guidelines

## Test plan

- [ ] Verify `docs/terraform.md` Outputs table shows proper descriptions for all outputs
- [ ] Verify `README.md` Outputs section reflects the same descriptions

+semver: major

🤖 Generated with [Claude Code](https://claude.com/claude-code)